### PR TITLE
Fix errori 11/12/2017

### DIFF
--- a/IncidCoord.m
+++ b/IncidCoord.m
@@ -1,13 +1,7 @@
 function [incidenze,coordinate,nset_sup] = IncidCoord
 
 
-global mesh_iniziale
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%%IncidCoord ha bisogno di un reverse rotate?%%%
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-dim_voxel = 0.032;
+global mesh_iniziale dim_voxel
 
 x_max = size(mesh_iniziale,1);
 y_max = size(mesh_iniziale,2);

--- a/Main.m
+++ b/Main.m
@@ -2,7 +2,7 @@
 clear
 clc
 
-global mesh_iniziale mesh_modificata sforzi incidenze SF
+global mesh_iniziale mesh_modificata sforzi incidenze SF dim_voxel
 
 %% PRIMO GIRO
 
@@ -21,22 +21,27 @@ mesh_iniziale = double(matrice_erosa_c);
 
 
 %% calcolo parametri macro e richiesta informazioni su input FEM e mesh
-x = inputdlg({'Direzione applicazione carico (x=1,y=2,z=3)','spostamento applicato (espresso in voxel)','Modulo elastico materiale - in GPa','Fattore di compressione (2, 3 o 6)'},...
+dati_ingresso = inputdlg({'Direzione applicazione carico (x=1,y=2,z=3)','spostamento applicato (espresso in voxel)','Modulo elastico materiale - in GPa','Fattore di compressione (2, 3 o 6)'},...
               'Parametri FEM e MESH'); 
+dati_ingresso = str2double(dati_ingresso);
+%converte cell in double, altrimenti non si puo' usare la sintassi x(4).
                                                     
-
 dim = size(mesh_iniziale,1);
-dim_voxel=  0.018*x(4); %dimensione del singolo voxel in millimetri
+dim_voxel=  0.018*dati_ingresso(4); %dimensione del singolo voxel in millimetri
 porosita=size(incidenze,1)/dim^3; %frazione volumetrica della mesh
-E_mat = x(3); %modulo elastico in GPa
+E_mat = dati_ingresso(3); %modulo elastico in GPa
 sigma_tot = sum(sforzi(:,2))*E_mat*10^3; 
 sigma_sp =  sigma_tot * porosita; %sforzo di comparazione con lo sforzo sperimentale
-epsilon = x(2)/dim;
+epsilon = dati_ingresso(2)/dim;
 E = [Cicli_iniziali sigma_sp/epsilon]; 
-alfa = E_sp/E(1,2);
 
-Rotate(x(1)); %porta le corrette rotazioni della matrice per allineare l'asse di carico con l'asse x 
-Sforzi4D(x(1)); 
+%alfa = E_sp/E(1,2);
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% dà errore, è da modificare quando utilizzeremo dati sperimentali.%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+Rotate(dati_ingresso(1)); %porta le corrette rotazioni della matrice per allineare l'asse di carico con l'asse x 
+Sforzi4D(dati_ingresso(1)); 
 mesh_modificata = mesh_iniziale;
 Ricerca_bordi;
 matrice_cricche = Crea_cricche(numero_cricche);
@@ -64,10 +69,11 @@ end
 
 %% eliminazione totale o parziale trabecola
 for i=1:size(matrice_cricche_modificata,1)
-    elimina_cerchio (matrice_cricche_modificata(i,:),dim_voxel);
+    elimina_cerchio (matrice_cricche_modificata(i,:));
 end
 
-Rotate(x(1)); %ritraspone le matrici in modo da ritornare alla configurazione originale prima di rinviare la mesh alla FEM
+%%
+Rotate(dati_ingresso(1)); %ritraspone le matrici in modo da ritornare alla configurazione originale prima di rinviare la mesh alla FEM
 
 % save('giro1.mat','mesh_iniziale','matrice_cricche_modificata','Cicli_finali','incidenze');
 

--- a/Paris.m
+++ b/Paris.m
@@ -19,6 +19,7 @@ function [ matrice_cricche, N_cicli] = Paris( matrice_cricche,N_cicli )
 %         interrotto il ciclo (trabecola inattivata o trabecola inattivata
 %         a meta')1
 
+global dim_voxel
 
 dK = @(c,dsigma) (pi*c*10^-3)^(1/2) * dsigma*10^3; % funzione che descrive il fattore di intensificazione degli sforzi
 C = 0.013; %parametro del materiale
@@ -27,7 +28,7 @@ m = 4.5; %parametro del materiale
 sigma=zeros(size(matrice_cricche,1));
 
 for i=1:size(matrice_cricche,1)
-    sigma(i) = Sforzo_medio(matrice_cricche(i,:),matrice_cricche(i,6)/(2*0.032)); %l'area su cui si calcola lo sforzo medio e' la meta' dello spessore della trabecola
+    sigma(i) = Sforzo_medio(matrice_cricche(i,:),matrice_cricche(i,6)/(2*dim_voxel)); %l'area su cui si calcola lo sforzo medio e' la meta' dello spessore della trabecola
 end
 
 while N_cicli<10e6

--- a/Sforzo_medio.m
+++ b/Sforzo_medio.m
@@ -20,6 +20,6 @@ for y=yc-R:yc+R
     end
 end
 
-sm = abs(mean(Sforzo_direzione_carico));
+sm = 13*abs(mean(Sforzo_direzione_carico));
 
 end

--- a/elimina_cerchio.m
+++ b/elimina_cerchio.m
@@ -3,20 +3,19 @@ function elimina_cerchio(riga_cricca)
 % dato una riga della matrice_cricche la funzione elimina i voxel pieni
 % nel cerchio concentrico nella cricca con raggio la lunghezza istantanea.
 
-global mesh_iniziale mesh_modificata
+global mesh_iniziale mesh_modificata dim_voxel
 
 dim = size(mesh_iniziale);
-a = 0.032;
-% fattore di conversione
-l_voxel = riga_cricca(5)/a;
+
+l_voxel = riga_cricca(5)/dim_voxel;
 % conversione
 xc = riga_cricca(1);
 
-for j = (riga_cricca(2)-floor(l_voxel)):(riga_cricca(2)+ceil(l_voxel))
-    for k = (riga_cricca(3)-floor(l_voxel/2)):(riga_cricca(3)+ceil(l_voxel/2))
-        if j>0 && j<dim(1) && k>0 && k<dim(3) 
+for j = floor(riga_cricca(2)-(l_voxel)):ceil(riga_cricca(2)+(l_voxel))
+    for k = floor(riga_cricca(3)-(l_voxel/2)):ceil(riga_cricca(3)+(l_voxel/2))
+        if j>0 && j<=dim(2) && k>0 && k<=dim(3) 
             % per non uscire dalla mesh
-            if sqrt((riga_cricca(1)-j)^2+(riga_cricca(3)-k)^2) <= l_voxel && ...
+            if hypot((riga_cricca(2)-j),(riga_cricca(3)-k)) <= l_voxel && ...
                     mesh_modificata(xc,riga_cricca(2),riga_cricca(3)) == mesh_modificata(xc,j,k)
         
                 % distanza con pitagora e condizione che verifica che il


### PR DESCRIPTION
elimina_cerchio :
-il cerchio eliminato non rispetta il raggio dato dalla matrice cricca, succede raramente ma non è ancora risolto.
-Riga 14-15, messo floor e ceil fuori dalla parentesi: una cricca con coordinata (5,5) e lunghezza istantanea 1.5 voxel, con floor e ceil dentro la funzione esaminava da 4 a 7. La mia intenzione era 3 a 7.
-Riga 16, modificato le condizioni di if, prima non si riusciva mai ad eliminare i voxel ai bordi di coordinata massima.
-Riga 18, le condizioni non teneva conto del nostro rotate e prendeva le coordinate x,z. Deve considerare le coordinate y,z. (hypot calcola l'ipotenusa).

IncidCoord.m :
messo dim_voxel come global var
(cosi si evitano errori, infatti per qualche ragione usavo sempre 0.032 come unità di lunghezza in mm per ogni voxel, che in verità è 0.036).

Main.m :
-Messo dim_voxel come variabile global, viene usato in più funzioni :
   *elimina_cerchio
   *IncidCoord
   *Paris
(cosi si evitano errori, infatti per qualche ragione usavo sempre 0.032 come unità di lunghezza in mm per ogni voxel, che in verità è 0.036).
-Riga 26, convertito cell2double perchè cell contiene dati stringa.
-Riga 24 e altri, Dati del inputdlg vengono salvati nella variabile dati_ingresso. (Prima si chiamava x, ma x viene usato dopo nella riga 61 per un altra cosa e riutilizzato nella riga 75 considerandolo ancora x del inputdlg).
-Riga 38, alfa è da modificare quando avremo dati sperimentali.
-Riga 75, aggiuto section per facilitare testing.

Paris :
idem IncidCoord

Sforzo_medio.m :
Paris è diventato lento, nel senso che ci mette tanto in termini di cicli per propagare le cricche. Ho messo il fattore 13 in riga 23. E' preferibile richiamare il fattore duplicativo dal Main, visto che è un parametro di input, quindi è ancora da modificare.